### PR TITLE
Add y-axis formatter for overview bar chart

### DIFF
--- a/ui/src/routes/index.lazy.tsx
+++ b/ui/src/routes/index.lazy.tsx
@@ -190,6 +190,7 @@ export function TheBarChart({ counts }: TheBarChartProps) {
           fontSize={12}
           tickLine={false}
           axisLine={false}
+          tickFormatter={(number) => Intl.NumberFormat("en-US", {notation: "compact", maximumFractionDigits: 1}).format(number)}
         />
         <Bar
           dataKey="count"


### PR DESCRIPTION
Fixes #7

<img width="308" alt="image" src="https://github.com/frectonz/sqlite-studio/assets/11244353/57900f51-02fc-445c-9abb-044ac0e2e639">
